### PR TITLE
Update regex to get PR number

### DIFF
--- a/src/pull_request.ts
+++ b/src/pull_request.ts
@@ -13,12 +13,12 @@ export class PullRequest {
 
   static parseFrom(commitMessage: string) {
     const pullRequestPartsRegex = new RegExp(
-      /Merge pull request #(\d*) .*?\n\n(.*)/
+      /(?:Merge pull request #(\d+).*?\n\n([\s\S]*)|([\s\S]*?)\s*\(#(\d+)\))/
     );
     const match = commitMessage.match(pullRequestPartsRegex);
 
-    const text = match[2];
-    const id = match[1];
+    const text = match[2] ?? match[3];
+    const id = match[1] ?? match[4];
     return new PullRequest(text, id, ChangeCategory.Basic);
   }
 


### PR DESCRIPTION
Now captures 2 variants of PR messages.

Examples:
- `Merge pull request #1 \n\nCreate release notes`
- `Create release notes (#1)`

has `id=1`, `text="Create release notes"`