### PR TITLE
Update regex to get commits that are PRs

### DIFF
--- a/src/components/changelog_creator.tsx
+++ b/src/components/changelog_creator.tsx
@@ -66,9 +66,11 @@ export class ChangeLogCreatorSections extends React.Component<Props, State> {
     releaseTag: string
   ) {
     console.log(typeof filterPullRequestMergeCommits);
-    const pullRequests = commits.map(commit =>
-      PullRequest.parseFrom(commit.commit.message)
-    );
+    const pullRequests = commits
+      .map(commit => PullRequest.parseFrom(commit.commit.message))
+      .filter(x => x !== null);
+
+    console.log("Parsed pull requests:", pullRequests);
     const pullRequestsWithLabels: PullRequestWithLabels[] =
       await addLabelsToPullRequests(
         pullRequests,

--- a/src/components/changelog_creator.tsx
+++ b/src/components/changelog_creator.tsx
@@ -5,7 +5,6 @@ import { Markdown } from "./markdown";
 import { Github, GithubTag, GithubCommit } from "../github";
 import {
   addLabelsToPullRequests,
-  filterPullRequestMergeCommits,
   groupPullRequestsByLabels,
   PullRequestWithLabels
 } from "../github_helper";
@@ -65,7 +64,6 @@ export class ChangeLogCreatorSections extends React.Component<Props, State> {
     startTag: string,
     releaseTag: string
   ) {
-    console.log(typeof filterPullRequestMergeCommits);
     const pullRequests = commits
       .map(commit => PullRequest.parseFrom(commit.commit.message))
       .filter(x => x !== null);

--- a/src/components/changelog_creator.tsx
+++ b/src/components/changelog_creator.tsx
@@ -70,7 +70,6 @@ export class ChangeLogCreatorSections extends React.Component<Props, State> {
       .map(commit => PullRequest.parseFrom(commit.commit.message))
       .filter(x => x !== null);
 
-    console.log("Parsed pull requests:", pullRequests);
     const pullRequestsWithLabels: PullRequestWithLabels[] =
       await addLabelsToPullRequests(
         pullRequests,

--- a/src/components/changelog_creator.tsx
+++ b/src/components/changelog_creator.tsx
@@ -65,7 +65,8 @@ export class ChangeLogCreatorSections extends React.Component<Props, State> {
     startTag: string,
     releaseTag: string
   ) {
-    const pullRequests = filterPullRequestMergeCommits(commits).map(commit =>
+    console.log(typeof filterPullRequestMergeCommits);
+    const pullRequests = commits.map(commit =>
       PullRequest.parseFrom(commit.commit.message)
     );
     const pullRequestsWithLabels: PullRequestWithLabels[] =

--- a/src/pull_request.ts
+++ b/src/pull_request.ts
@@ -18,6 +18,9 @@ export class PullRequest {
     const match = commitMessage.match(pullRequestPartsRegex);
     console.log("matches", match);
     console.log("commitMessage", commitMessage);
+    if (!match) {
+      return null;
+    }
     const text = match[2] ?? match[3];
     const id = match[1] ?? match[4];
     console.log("Parsed PR:", { text, id });

--- a/src/pull_request.ts
+++ b/src/pull_request.ts
@@ -16,9 +16,12 @@ export class PullRequest {
       /(?:Merge pull request #(\d+).*?\n\n([\s\S]*)|([\s\S]*?)\s*\(#(\d+)\))/
     );
     const match = commitMessage.match(pullRequestPartsRegex);
-
+    console.log("matches", match);
+    console.log("commitMessage", commitMessage);
     const text = match[2] ?? match[3];
     const id = match[1] ?? match[4];
+    console.log("Parsed PR:", { text, id });
+
     return new PullRequest(text, id, ChangeCategory.Basic);
   }
 

--- a/src/pull_request.ts
+++ b/src/pull_request.ts
@@ -16,14 +16,11 @@ export class PullRequest {
       /(?:Merge pull request #(\d+).*?\n\n([\s\S]*)|([\s\S]*?)\s*\(#(\d+)\))/
     );
     const match = commitMessage.match(pullRequestPartsRegex);
-    console.log("matches", match);
-    console.log("commitMessage", commitMessage);
     if (!match) {
       return null;
     }
     const text = match[2] ?? match[3];
     const id = match[1] ?? match[4];
-    console.log("Parsed PR:", { text, id });
 
     return new PullRequest(text, id, ChangeCategory.Basic);
   }

--- a/src/pull_request.ts
+++ b/src/pull_request.ts
@@ -13,12 +13,12 @@ export class PullRequest {
 
   static parseFrom(commitMessage: string) {
     const pullRequestPartsRegex = new RegExp(
-      /Merge pull request #(\d*) .*?\n\n(.*)/
+      /(?:Merge pull request #(\d+).*?\n\n([\s\S]*)|([\s\S]*?)\s*\(#(\d+)\))/
     );
     const match = commitMessage.match(pullRequestPartsRegex);
 
-    const text = match[2];
-    const id = match[1];
+    const text = match[2] ?? match[3];
+    const id = match[1] ?? match[4];
     return new PullRequest(text, id, ChangeCategory.Basic);
   }
 


### PR DESCRIPTION
Now captures 2 variants of PR commit messages.

Examples:
- `Merge pull request #1 \n\nCreate release notes`
- `Create release notes (#1)`

has `id=1`, `text="Create release notes"`